### PR TITLE
Add tox.ini for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26, py27, pypy, py33, py34, pypy3
+
+[testenv]
+deps =
+    pytest
+commands = py.test {posargs:-v}


### PR DESCRIPTION
This adds support for the [tox](http://tox.testrun.org/) testing tool.

```
marca@marca-mac2:~/dev/git-repos/python-dataprint$ pip install tox
...
marca@marca-mac2:~/dev/git-repos/python-dataprint$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy3: commands succeeded
  congratulations :)
```
