### PR TITLE
use setuptools for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='DataPrint',
       version='1.1',


### PR DESCRIPTION
Following the guideance from
http://stackoverflow.com/questions/6344076/differences-between-distribute-distutils-setuptools-and-distutils2

This PR motivated by the current code not supporting
`python setup.py develop` for local development, but setuptools
makes it work