### PR TITLE
handle unicode happily for py2k

### DIFF
--- a/dataprint.py
+++ b/dataprint.py
@@ -181,7 +181,8 @@ to True in order to overwrite the file.")
 					else:
 						item_str = item
 				else:
-					item_str = self._separator.join(str(item).split())
+					item_str = u'{}'.format(item)
+					item_str = self._separator.join(item_str.split())
 
 				column_index = j
 
@@ -196,7 +197,8 @@ to True in order to overwrite the file.")
 					else:
 						istr = item
 				else:
-					istr = self._separator.join(str(item).split())
+					istr = u'{}'.format(item)
+					istr = self._separator.join(istr.split())
 
 				pad = (col_idx != len(row) - 1)
 


### PR DESCRIPTION
basically, don't use the `str` function and things are happy

Change passes test cases for py2k and py3k locally, and fixes
my current problem [not the least of which is being stuck
using py2k...]