### PR TITLE
don't restrict file-like types

### DIFF
--- a/dataprint.py
+++ b/dataprint.py
@@ -113,10 +113,8 @@ to True in order to overwrite the file.")
 				raise DataPrinterException("Cannot write to file.")
 			self.format(data, fd)
 		else:
-			if PY3 or (type(fd) is not file):
+			if not hasattr(fd, 'write'):
 				raise DataPrinterException("Provided file descriptor was not valid.")
-			if 'w' not in fd.mode:
-				raise DataPrinterException("Cannot write to file.")
 			self.format(data, fd)
 
 	def format (self, data, outfile):


### PR DESCRIPTION
Following the advice from
https://stackoverflow.com/questions/1661262/check-if-object-is-file-like-in-python
all dataprint really cares about is whether it can `write` to the things it's given

Without this patch, `tempfile.TemporaryFile` objects could not be passed to dataprint